### PR TITLE
fix: Chart appearance

### DIFF
--- a/app.R
+++ b/app.R
@@ -151,9 +151,12 @@ ui <- fluidPage(
               hr(),
               h4("Stimmen aus veränderten Listen"),
               
-              chart_container
-              
-            )
+            ),
+
+            # Chart container; can't be used in a conditional panel as when the
+            # update_data function is called, the UI is not ready yet when JS tries
+            # to target container id.
+            chart_container
 
         )
     )
@@ -298,17 +301,22 @@ server <- function(input, output, session) {
     observeEvent(input$show_details,
                  { 
                    req(global$activeButton == TRUE)
-                   req(selected_row_number() > 0)
                    
-                   person <- filtered_data() %>%
-                     filter(Name == data_person()$Name) %>% 
-                     filter(Wahlkreis == data_person()$Wahlkreis) %>% 
-                     filter(ListeBezeichnung == data_person()$ListeBezeichnung) %>% 
-                     select(Name, StimmeVeraeListe, Value) %>% 
-                     filter(!is.na(Value) & Value > 0) %>%
-                     arrange(desc(Value))
-                   
-                   update_data(person) 
+                   if (selected_row_number() > 0) {
+                     person <- filtered_data() %>%
+                       filter(Name == data_person()$Name) %>% 
+                       filter(Wahlkreis == data_person()$Wahlkreis) %>% 
+                       filter(ListeBezeichnung == data_person()$ListeBezeichnung) %>% 
+                       select(Name, StimmeVeraeListe, Value) %>% 
+                       filter(!is.na(Value) & Value > 0) %>%
+                       arrange(desc(Value))
+                     
+                     update_data(person)   
+                   } else {
+                    # sendCustomMessage requires a message argument to be defined,
+                    # even though it's not needed in this case.
+                     session$sendCustomMessage(type = "clear_chart", message="")
+                   }
                   })
     
     

--- a/www/script.js
+++ b/www/script.js
@@ -243,3 +243,9 @@ Shiny.addCustomMessageHandler("update_data", function (data) {
   }
 });
 
+// Used to clear the contents of a chart.
+// customMessageHandler requires a function argument to be defined (message),
+// even though it's not needed in this case.
+Shiny.addCustomMessageHandler("clear_chart", function (message) {
+  d3.select(CHART_CONTAINER_ID).selectAll("*").remove();
+});


### PR DESCRIPTION
This PR fixes the problem of chart that is not updated on a first table row click (or is not cleared when switching filtering params).

There are two approaches to the problem; chart container could be either:
- inside conditional panel – in this case, (I believe) the message to update the data and render a chart was sent before UI had a chance to be rendered (basically there was no chart container present yet),
- outside conditional panel – in this case, chart was not reset after changing filtering parameters.

Not ideal, but one solution to this problem is to put chart container outside the conditional panel, so it would be always here; but when the "show details" variable is set to false, we clear the chart by removing all of its contents.